### PR TITLE
perf: add optimized zip* and cross* for arrays

### DIFF
--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -907,6 +907,45 @@ export const zipWith = <B, A, C>(fb: ReadonlyArray<B>, f: (a: A, b: B) => C) =>
   }
 
 /**
+ * @since 1.0.0
+ */
+export const zipMany = <A>(collection: Iterable<ReadonlyArray<A>>) =>
+  (self: ReadonlyArray<A>): ReadonlyArray<readonly [A, ...Array<A>]> => {
+    if (self.length === 0) {
+      return []
+    }
+
+    const arrays = Array.from(collection)
+    const out: Array<[A, ...Array<A>]> = []
+
+    for (let i = 0; i < self.length; i++) {
+      const inner: [A, ...Array<A>] = [self[i]]
+      for (const array of arrays) {
+        if (i > array.length - 1) {
+          return out
+        }
+        inner.push(array[i])
+      }
+      out.push(inner)
+    }
+
+    return out
+  }
+
+/**
+ * @since 1.0.0
+ */
+export const zipAll = <A>(
+  collection: Iterable<ReadonlyArray<A>>
+): ReadonlyArray<ReadonlyArray<A>> => {
+  const arrays = Array.from(collection)
+  if (arrays.length === 0) {
+    return []
+  }
+  return zipMany(arrays.slice(1))(arrays[0])
+}
+
+/**
  * Takes two `ReadonlyArray`s and returns a `ReadonlyArray` of corresponding pairs. If one input `ReadonlyArray` is short, excess elements of the
  * longer `ReadonlyArray` are discarded.
  *
@@ -1630,14 +1669,7 @@ export const unit: (self: ReadonlyArray<unknown>) => ReadonlyArray<void> = funct
 export const Semigroupal: semigroupal.Semigroupal<ReadonlyArrayTypeLambda> = {
   map,
   zipWith,
-  zipMany: <A>(others: Iterable<ReadonlyArray<A>>) =>
-    (start: ReadonlyArray<A>): ReadonlyArray<[A, ...Array<A>]> => {
-      let c: ReadonlyArray<[A, ...Array<A>]> = pipe(start, map((a) => [a]))
-      for (const o of others) {
-        c = pipe(c, zipWith(o, (a, b) => [...a, b]))
-      }
-      return c
-    }
+  zipMany
 }
 
 /**
@@ -1673,13 +1705,7 @@ export const Monoidal: monoidal.Monoidal<ReadonlyArrayTypeLambda> = {
   of,
   zipMany: Semigroupal.zipMany,
   zipWith: Semigroupal.zipWith,
-  zipAll: <A>(collection: Iterable<ReadonlyArray<A>>): ReadonlyArray<ReadonlyArray<A>> => {
-    let c: ReadonlyArray<ReadonlyArray<A>> = [[], ...[]]
-    for (const o of collection) {
-      c = pipe(c, zipWith(o, (a, b) => [...a, b]))
-    }
-    return c
-  }
+  zipAll
 }
 
 /**

--- a/test/NonEmptyReadonlyArray.ts
+++ b/test/NonEmptyReadonlyArray.ts
@@ -850,4 +850,25 @@ describe.concurrent("NonEmptyReadonlyArray", () => {
 
     expect(actual).toStrictEqual(expected)
   })
+
+  test("crossWith", () => {
+    const self = NonEmptyReadonlyArray.make(1, 2, 3)
+    const that = NonEmptyReadonlyArray.make(2, 3, 4)
+
+    const actual = pipe(self, NonEmptyReadonlyArray.crossWith(that, (a, b) => a * b))
+    const expected = [2, 3, 4, 4, 6, 8, 6, 9, 12]
+
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("crossAll", () => {
+    const arrays: ReadonlyArray<NonEmptyReadonlyArray.NonEmptyReadonlyArray<number>> = [
+      [2, 3],
+      [4, 5],
+      [8, 9, 10]
+    ]
+    const actual = NonEmptyReadonlyArray.crossAll(arrays)
+    const expected = [[2, 4, 5, 8, 9, 10], [3, 4, 5, 8, 9, 10]]
+    expect(actual).toStrictEqual(expected)
+  })
 })

--- a/test/NonEmptyReadonlyArray.ts
+++ b/test/NonEmptyReadonlyArray.ts
@@ -823,4 +823,31 @@ describe.concurrent("NonEmptyReadonlyArray", () => {
     deepStrictEqual(NonEmptyReadonlyArray.concat([])(["a"]), ["a"])
     deepStrictEqual(NonEmptyReadonlyArray.concat(["b"])([]), ["b"])
   })
+
+  test("zipMany", () => {
+    const start = NonEmptyReadonlyArray.make(1, 2, 3, 4, 5)
+    const others = [
+      NonEmptyReadonlyArray.make(1, 2, 3, 4, 5, 6),
+      NonEmptyReadonlyArray.make(1, 2, 3, 4),
+      NonEmptyReadonlyArray.make(1, 2, 3, 4, 5)
+    ]
+
+    const actual = pipe(start, NonEmptyReadonlyArray.zipMany(others))
+    const expected = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
+
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("zipAll", () => {
+    const arrays = [
+      NonEmptyReadonlyArray.make(1, 2, 3, 4, 5, 6),
+      NonEmptyReadonlyArray.make(1, 2, 3, 4),
+      NonEmptyReadonlyArray.make(1, 2, 3, 4, 5)
+    ]
+
+    const actual = NonEmptyReadonlyArray.zipAll(arrays)
+    const expected = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
+
+    expect(actual).toStrictEqual(expected)
+  })
 })

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1254,7 +1254,7 @@ describe.concurrent("ReadonlyArray", () => {
       [1, 2, 3, 4, 5]
     ]
 
-    const actual = pipe(start, ReadonlyArray.Semigroupal.zipMany(others))
+    const actual = pipe(start, ReadonlyArray.zipMany(others))
     const expected = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
 
     expect(actual).toStrictEqual(expected)
@@ -1270,6 +1270,39 @@ describe.concurrent("ReadonlyArray", () => {
     const actual = ReadonlyArray.zipAll(arrays)
     const expected = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
 
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("crossWith", () => {
+    const self = [1, 2, 3]
+    const that = [2, 3, 4]
+
+    const actual = pipe(self, ReadonlyArray.crossWith(that, (a, b) => a * b))
+    const expected = [2, 3, 4, 4, 6, 8, 6, 9, 12]
+
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("crossMany", () => {
+    const self = [1, 2, 3]
+    const arrays = [
+      [2],
+      [4, 5],
+      [8, 9, 10]
+    ]
+    const actual = pipe(self, ReadonlyArray.crossMany(arrays))
+    const expected = [[1, 2, 4, 5, 8, 9, 10], [2, 2, 4, 5, 8, 9, 10], [3, 2, 4, 5, 8, 9, 10]]
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("crossAll", () => {
+    const arrays = [
+      [2, 3],
+      [4, 5],
+      [8, 9, 10]
+    ]
+    const actual = ReadonlyArray.crossAll(arrays)
+    const expected = [[2, 4, 5, 8, 9, 10], [3, 4, 5, 8, 9, 10]]
     expect(actual).toStrictEqual(expected)
   })
 })

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1245,4 +1245,31 @@ describe.concurrent("ReadonlyArray", () => {
     deepStrictEqual(pipe(ReadonlyArray.empty, f), "empty")
     deepStrictEqual(pipe([1, 2, 3], f), "nonEmpty 3")
   })
+
+  test("zipMany", () => {
+    const start = [1, 2, 3, 4, 5]
+    const others = [
+      [1, 2, 3, 4, 5, 6],
+      [1, 2, 3, 4],
+      [1, 2, 3, 4, 5]
+    ]
+
+    const actual = pipe(start, ReadonlyArray.Semigroupal.zipMany(others))
+    const expected = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
+
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("zipAll", () => {
+    const arrays = [
+      [1, 2, 3, 4, 5, 6],
+      [1, 2, 3, 4],
+      [1, 2, 3, 4, 5]
+    ]
+
+    const actual = ReadonlyArray.zipAll(arrays)
+    const expected = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
+
+    expect(actual).toStrictEqual(expected)
+  })
 })


### PR DESCRIPTION
Adds optimized implementations of `zipMany` and `zipAll` for `ReadonlyArray` and `NonEmptyReadonlyArray`.

I'm not _100%_ sure that these follow the rules of what `zipMany` and `zipAll` should do 🙂