### PR TITLE
get rid of artificial covariance fields

### DIFF
--- a/.changeset/red-glasses-drive.md
+++ b/.changeset/red-glasses-drive.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/data": patch
+---
+
+get rid of artificial covariance fields

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -27,7 +27,6 @@ export type TypeId = typeof TypeId
  */
 export interface Chunk<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
 
   readonly length: number
 
@@ -124,7 +123,6 @@ const BufferSize = 64
 /** @internal */
 class ChunkImpl<A> implements Chunk<A> {
   readonly _id: typeof TypeId = TypeId
-  readonly _A: (_: never) => A = (_) => _
 
   readonly length: number
   readonly depth: number

--- a/src/HashMap.ts
+++ b/src/HashMap.ts
@@ -25,8 +25,6 @@ export type TypeId = typeof TypeId
  */
 export interface HashMap<Key, Value> extends Iterable<readonly [Key, Value]>, Equal {
   readonly _id: TypeId
-  readonly _Key: (_: never) => Key
-  readonly _Value: (_: never) => Value
 }
 
 /**

--- a/src/HashSet.ts
+++ b/src/HashSet.ts
@@ -21,7 +21,6 @@ export type TypeId = typeof TypeId
  */
 export interface HashSet<A> extends Iterable<A>, Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
 }
 
 /**

--- a/src/List.ts
+++ b/src/List.ts
@@ -39,7 +39,6 @@ export type TypeId = typeof TypeId
 export interface Cons<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
   readonly _tag: "Cons"
-  readonly _A: (_: never) => A
   readonly head: A
   readonly tail: List<A>
 }
@@ -51,7 +50,6 @@ export interface Cons<A> extends Iterable<A>, Equal.Equal {
 export interface Nil<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
   readonly _tag: "Nil"
-  readonly _A: (_: never) => A
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -24,7 +24,6 @@ export type TypeId = typeof TypeId
  */
 export interface Queue<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
   /** @internal */
   readonly _in: L.List<A>
   /** @internal */

--- a/src/RedBlackTree.ts
+++ b/src/RedBlackTree.ts
@@ -31,8 +31,6 @@ export const Direction = RBTI.Direction
  */
 export interface RedBlackTree<Key, Value> extends Iterable<readonly [Key, Value]>, Equal {
   readonly _id: TypeId
-  readonly _Key: (_: never) => Key
-  readonly _Value: (_: never) => Value
 }
 
 /**

--- a/src/SortedMap.ts
+++ b/src/SortedMap.ts
@@ -22,8 +22,6 @@ export type TypeId = typeof TypeId
  */
 export interface SortedMap<K, V> extends Iterable<readonly [K, V]>, Eq.Equal {
   readonly _id: TypeId
-  readonly _K: (_: never) => K
-  readonly _V: (_: never) => V
   /** @internal */
   readonly tree: RBT.RedBlackTree<K, V>
 }
@@ -31,8 +29,6 @@ export interface SortedMap<K, V> extends Iterable<readonly [K, V]>, Eq.Equal {
 /** @internal */
 class SortedMapImpl<K, V> implements Iterable<readonly [K, V]>, Eq.Equal {
   readonly _id: TypeId = TypeId
-  readonly _K: (_: never) => K = (_) => _
-  readonly _V: (_: never) => V = (_) => _
 
   constructor(readonly tree: RBT.RedBlackTree<K, V>) {}
 

--- a/src/SortedSet.ts
+++ b/src/SortedSet.ts
@@ -23,7 +23,6 @@ export type TypeId = typeof TypeId
  */
 export interface SortedSet<A> extends Iterable<A>, Eq.Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
   /** @internal */
   readonly keyTree: RBT.RedBlackTree<A, boolean>
 }
@@ -31,7 +30,6 @@ export interface SortedSet<A> extends Iterable<A>, Eq.Equal {
 /** @internal */
 class SortedSetImpl<A> implements Iterable<A>, Eq.Equal {
   readonly _id: TypeId = TypeId
-  readonly _A: (_: never) => A = (_) => _
 
   constructor(readonly keyTree: RBT.RedBlackTree<A, boolean>) {}
 

--- a/src/internal/HashMap.ts
+++ b/src/internal/HashMap.ts
@@ -28,15 +28,9 @@ interface VisitResult<K, V, A> {
   cont: Cont<K, V, A>
 }
 
-function variance<A, B>(_: A): B {
-  return _ as unknown as B
-}
-
 /** @internal */
 export class HashMapImpl<K, V> implements HM.HashMap<K, V> {
   readonly _id: HM.TypeId = HashMapTypeId
-  readonly _Key: (_: never) => K = variance
-  readonly _Value: (_: never) => V = variance
   constructor(
     public _editable: boolean,
     public _edit: number,

--- a/src/internal/HashSet.ts
+++ b/src/internal/HashSet.ts
@@ -8,14 +8,9 @@ import type { Refinement } from "@fp-ts/data/Refinement"
 /** @internal */
 export const HashSetTypeId: HS.TypeId = Symbol.for("@fp-ts/data/HashSet") as HS.TypeId
 
-function variance<A, B>(_: A): B {
-  return _ as unknown as B
-}
-
 /** @internal */
 export class HashSetImpl<A> implements HS.HashSet<A> {
   readonly _id: HS.TypeId = HashSetTypeId
-  readonly _A: (_: never) => A = variance
 
   constructor(readonly _keyMap: HashMap<A, unknown>) {}
 

--- a/src/internal/List.ts
+++ b/src/internal/List.ts
@@ -23,7 +23,6 @@ export const ListTypeId: L.TypeId = Symbol.for("@fp-ts/data/List") as L.TypeId
 /** @internal */
 export class ConsImpl<A> implements Iterable<A>, L.Cons<A>, DE.Equal {
   readonly _tag = "Cons"
-  readonly _A: (_: never) => A = (_) => _
   readonly _id: L.TypeId = ListTypeId
   constructor(readonly head: A, public tail: L.List<A>) {}
   [DE.symbolHash](): number {
@@ -67,7 +66,6 @@ export class ConsImpl<A> implements Iterable<A>, L.Cons<A>, DE.Equal {
 /** @internal */
 export class NilImpl<A> implements Iterable<A>, L.Nil<A>, DE.Equal {
   readonly _tag = "Nil"
-  readonly _A: (_: never) => A = (_) => _
   readonly _id: L.TypeId = ListTypeId;
 
   [DE.symbolHash](): number {

--- a/src/internal/Queue.ts
+++ b/src/internal/Queue.ts
@@ -22,7 +22,6 @@ export const QueueTypeId: Q.TypeId = Symbol.for("@fp-ts/data/Queue") as Q.TypeId
 
 class QueueImpl<A> implements Q.Queue<A>, Iterable<A>, DE.Equal {
   readonly _id: Q.TypeId = QueueTypeId
-  readonly _A: (_: never) => A = (_) => _
   constructor(public _in: L.List<A>, public _out: L.List<A>) {}
   [Symbol.iterator](): Iterator<A> {
     return pipe(this._out, II.concat(L.reverse(this._in)))[Symbol.iterator]()

--- a/src/internal/RedBlackTree.ts
+++ b/src/internal/RedBlackTree.ts
@@ -12,14 +12,8 @@ const RedBlackTreeSymbolKey = "@fp-ts/data/RedBlackTree"
 /** @internal */
 export const RedBlackTreeTypeId: RBT.TypeId = Symbol.for(RedBlackTreeSymbolKey) as RBT.TypeId
 
-function variance<A, B>(_: A): B {
-  return _ as unknown as B
-}
-
 export class RedBlackTreeImpl<K, V> implements RBT.RedBlackTree<K, V> {
   readonly _id: RBT.TypeId = RedBlackTreeTypeId
-  readonly _Key: (_: never) => K = variance
-  readonly _Value: (_: never) => V = variance
 
   constructor(
     readonly _ord: Order.Order<K>,

--- a/src/mutable/MutableHashMap.ts
+++ b/src/mutable/MutableHashMap.ts
@@ -50,9 +50,6 @@ class Node<K, V> implements Iterable<readonly [K, V]> {
 export interface MutableHashMap<K, V> extends Iterable<readonly [K, V]>, Equal.Equal {
   readonly _id: TypeId
 
-  readonly _K: (_: K) => K
-  readonly _V: (_: never) => V
-
   /** @internal */
   readonly backingMap: Map<number, Node<K, V>>
   /** @internal */
@@ -62,9 +59,6 @@ export interface MutableHashMap<K, V> extends Iterable<readonly [K, V]>, Equal.E
 /** @internal */
 class MutableHashMapImpl<K, V> implements MutableHashMap<K, V> {
   readonly _id: TypeId = TypeId
-
-  readonly _K: (_: K) => K = (_) => _
-  readonly _V: (_: never) => V = (_) => _
 
   readonly backingMap = new Map<number, Node<K, V>>()
   length = 0;

--- a/src/mutable/MutableList.ts
+++ b/src/mutable/MutableList.ts
@@ -18,7 +18,6 @@ export type TypeId = typeof TypeId
  */
 export interface MutableList<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
 
   /** @internal */
   head: LinkedListNode<A> | undefined
@@ -26,14 +25,9 @@ export interface MutableList<A> extends Iterable<A>, Equal.Equal {
   tail: LinkedListNode<A> | undefined
 }
 
-function variance<A, B>(_: A): B {
-  return _ as unknown as B
-}
-
 /** @internal */
 class MutableListImpl<A> implements MutableList<A> {
   readonly _id: TypeId = TypeId
-  readonly _A: (_: never) => A = variance
 
   head: LinkedListNode<A> | undefined = undefined
   tail: LinkedListNode<A> | undefined = undefined

--- a/src/mutable/MutableQueue.ts
+++ b/src/mutable/MutableQueue.ts
@@ -26,7 +26,6 @@ export const EmptyMutableQueue = Symbol.for("@fp-ts/data/mutable/MutableQueue/Em
  */
 export interface MutableQueue<A> extends Iterable<A>, Equal.Equal {
   readonly _id: TypeId
-  readonly _A: (_: never) => A
 
   /** @internal */
   queue: MutableList.MutableList<A>
@@ -41,15 +40,10 @@ export declare namespace MutableQueue {
   export type Empty = typeof EmptyMutableQueue
 }
 
-function variance<A, B>(_: A): B {
-  return _ as unknown as B
-}
-
 /** @internal */
 class MutableQueueImpl<A> implements MutableQueue<A> {
   readonly _tag = "Bounded"
   readonly _id: TypeId = TypeId
-  readonly _A: (_: never) => A = variance
 
   queue: MutableList.MutableList<A> = MutableList.empty()
 


### PR DESCRIPTION
The defintion of the following data types:

- `Chunk`
- `HashMap`
- `HashSet`
- `List`
- `Queue`
- `RedBlackTree`
- `SortedMap`
- `SortedSet`
- `MutableList`
- `MutableQueue`

declares a `_A` field (or `_K` / `_V` fields) to enforce covariance, however covariance is already enforced by extending `Iterable`, this PR aims to get rid of those "artificial" fields.
