### PR TITLE
List: add `@fp-ts/core@0.0.6` instances and 100% test coverage

### DIFF
--- a/.changeset/fluffy-cycles-check.md
+++ b/.changeset/fluffy-cycles-check.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/data": patch
+---
+
+List: fix take and add core@0.0.6 instances / functions

--- a/src/List.ts
+++ b/src/List.ts
@@ -2,11 +2,29 @@
  * @since 1.0.0
  */
 
-import type * as HKT from "@fp-ts/core/HKT"
+import type { Kind, TypeLambda } from "@fp-ts/core/HKT"
+import * as applicative from "@fp-ts/core/typeclass/Applicative"
+import * as chainable from "@fp-ts/core/typeclass/Chainable"
+import * as compactable from "@fp-ts/core/typeclass/Compactable"
+import type { Coproduct } from "@fp-ts/core/typeclass/Coproduct"
+import * as covariant from "@fp-ts/core/typeclass/Covariant"
+import * as filterable from "@fp-ts/core/typeclass/Filterable"
+import * as flatMap_ from "@fp-ts/core/typeclass/FlatMap"
+import * as foldable from "@fp-ts/core/typeclass/Foldable"
+import * as invariant from "@fp-ts/core/typeclass/Invariant"
+import type * as monad from "@fp-ts/core/typeclass/Monad"
+import type { Monoid } from "@fp-ts/core/typeclass/Monoid"
+import * as nonEmptyApplicative from "@fp-ts/core/typeclass/NonEmptyApplicative"
+import * as nonEmptyProduct from "@fp-ts/core/typeclass/NonEmptyProduct"
+import * as of_ from "@fp-ts/core/typeclass/Of"
 import type { Order } from "@fp-ts/core/typeclass/Order"
+import type * as pointed from "@fp-ts/core/typeclass/Pointed"
+import * as product_ from "@fp-ts/core/typeclass/Product"
+import type { Semigroup } from "@fp-ts/core/typeclass/Semigroup"
+import * as traversable from "@fp-ts/core/typeclass/Traversable"
+import * as traversableFilterable from "@fp-ts/core/typeclass/TraversableFilterable"
 import type { Either } from "@fp-ts/data/Either"
 import type * as Equal from "@fp-ts/data/Equal"
-import { pipe } from "@fp-ts/data/Function"
 import * as LI from "@fp-ts/data/internal/List"
 import * as _sort from "@fp-ts/data/internal/List/sort"
 import type { Option } from "@fp-ts/data/Option"
@@ -62,7 +80,7 @@ export type List<A> = Cons<A> | Nil<A>
  * @since 1.0.0
  * @category type lambdas
  */
-export interface ListTypeLambda extends HKT.TypeLambda {
+export interface ListTypeLambda extends TypeLambda {
   readonly type: List<this["Target"]>
 }
 
@@ -110,15 +128,6 @@ export const take: (n: number) => <A>(self: List<A>) => List<A> = LI.take
 
 /**
  * @since 1.0.0
- * @category filtering
- */
-export const filter: {
-  <A, B extends A>(p: Refinement<A, B>): (self: List<A>) => List<B>
-  <A>(p: Predicate<A>): (self: List<A>) => List<A>
-} = LI.filter
-
-/**
- * @since 1.0.0
  * @category refinements
  */
 export const isList: {
@@ -161,22 +170,6 @@ export const concat: <B>(prefix: List<B>) => <A>(self: List<A>) => List<A | B> =
  * @category mutations
  */
 export const reverse: <A>(self: List<A>) => List<A> = LI.reverse
-
-/**
- * @since 1.0.0
- * @category partitioning
- */
-export const partition: <A>(
-  f: Predicate<A>
-) => (self: List<A>) => readonly [List<A>, List<A>] = LI.partition
-
-/**
- * @since 1.0.0
- * @category partitioning
- */
-export const partitionMap: <A, B, C>(
-  f: (a: A) => Either<B, C>
-) => (self: List<A>) => readonly [List<B>, List<C>] = LI.partitionMap
 
 /**
  * @since 1.0.0
@@ -255,13 +248,6 @@ export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (self: List<A>) => B 
 
 /**
  * @since 1.0.0
- * @category apply
- */
-export const ap: <A>(fa: List<A>) => <B>(self: List<(a: A) => B>) => List<B> = (fa) =>
-  (fab) => pipe(fab, flatMap((f) => pipe(fa, map((a) => f(a)))))
-
-/**
- * @since 1.0.0
  * @category unsafe
  */
 export const unsafeHead: <A>(self: List<A>) => A = LI.unsafeHead
@@ -283,3 +269,523 @@ export const unsafeLast: <A>(self: List<A>) => A = LI.unsafeLast
  * @category sorting
  */
 export const sort: <A>(O: Order<A>) => (self: List<A>) => List<A> = _sort.sort
+
+/**
+ * @since 1.0.0
+ * @category mapping
+ */
+export const imap: <A, B>(to: (a: A) => B, from: (b: B) => A) => (self: List<A>) => List<B> =
+  LI.imap
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Invariant: invariant.Invariant<ListTypeLambda> = LI.Invariant
+
+/**
+ * @since 1.0.0
+ */
+export const tupled: <A>(self: List<A>) => List<readonly [A]> = invariant.tupled(Invariant)
+
+/**
+ * @since 1.0.0
+ */
+export const bindTo: <N extends string>(
+  name: N
+) => <A>(self: List<A>) => List<{ readonly [K in N]: A }> = invariant.bindTo(Invariant)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Covariant: covariant.Covariant<ListTypeLambda> = LI.Covariant
+
+/**
+ * @category mapping
+ * @since 1.0.0
+ */
+export const as: <B>(b: B) => <_>(self: List<_>) => List<B> = covariant.as(Covariant)
+
+/**
+ * @category mapping
+ * @since 1.0.0
+ */
+export const asUnit: <_>(self: List<_>) => List<void> = covariant.asUnit(Covariant)
+
+/**
+ * @category mapping
+ * @since 1.0.0
+ */
+export const flap: <A>(a: A) => <B>(self: List<(a: A) => B>) => List<B> = covariant.flap(
+  Covariant
+)
+
+const let_: <N extends string, A extends object, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (
+  self: List<A>
+) => List<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = covariant.let(Covariant)
+
+export {
+  /**
+   * @category do notation
+   * @since 1.0.0
+   */
+  let_ as let
+}
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Of: of_.Of<ListTypeLambda> = {
+  of
+}
+
+/**
+ * @since 1.0.0
+ */
+export const unit: List<void> = of_.unit(Of)
+
+/**
+ * @since 1.0.0
+ */
+export const Do: List<{}> = of_.Do(Of)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Pointed: pointed.Pointed<ListTypeLambda> = {
+  ...Covariant,
+  ...Of
+}
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const FlatMap: flatMap_.FlatMap<ListTypeLambda> = {
+  flatMap
+}
+
+/**
+ * @since 1.0.0
+ */
+export const flatten: <A>(self: List<List<A>>) => List<A> = flatMap_
+  .flatten(FlatMap)
+
+/**
+ * @since 1.0.0
+ */
+export const andThen: <B>(that: List<B>) => <_>(self: List<_>) => List<B> = flatMap_.andThen(
+  FlatMap
+)
+
+/**
+ * @since 1.0.0
+ */
+export const composeKleisliArrow: <B, C>(
+  bfc: (b: B) => List<C>
+) => <A>(afb: (a: A) => List<B>) => (a: A) => List<C> = flatMap_.composeKleisliArrow(
+  FlatMap
+)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Chainable: chainable.Chainable<ListTypeLambda> = {
+  ...FlatMap,
+  ...Covariant
+}
+
+/**
+ * @since 1.0.0
+ */
+export const tap: <A, _>(
+  f: (a: A) => List<_>
+) => (self: List<A>) => List<A> = chainable.tap(Chainable)
+
+/**
+ * @since 1.0.0
+ */
+export const andThenDiscard: <_>(
+  that: List<_>
+) => <A>(self: List<A>) => List<A> = chainable.andThenDiscard(Chainable)
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
+export const bind: <N extends string, A extends object, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => List<B>
+) => (
+  self: List<A>
+) => List<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = chainable.bind(Chainable)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Monad: monad.Monad<ListTypeLambda> = {
+  ...Chainable,
+  ...Of
+}
+
+/**
+ * @since 1.0.0
+ */
+export const product: <B>(that: List<B>) => <A>(self: List<A>) => List<readonly [A, B]> = LI.product
+
+/**
+ * @since 1.0.0
+ */
+export const productMany: <A>(
+  collection: Iterable<List<A>>
+) => (self: List<A>) => List<readonly [A, ...Array<A>]> = LI.productMany
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const NonEmptyProduct: nonEmptyProduct.NonEmptyProduct<ListTypeLambda> = {
+  ...Invariant,
+  product,
+  productMany
+}
+
+/**
+ * @since 1.0.0
+ */
+export const bindList: <N extends string, A extends object, B>(
+  name: Exclude<N, keyof A>,
+  fb: List<B>
+) => (
+  self: List<A>
+) => List<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = nonEmptyProduct.bindKind(
+  NonEmptyProduct
+)
+
+/**
+ * @since 1.0.0
+ */
+export const productFlatten: <B>(
+  that: List<B>
+) => <A extends ReadonlyArray<any>>(self: List<A>) => List<readonly [...A, B]> = nonEmptyProduct
+  .productFlatten(NonEmptyProduct)
+
+/**
+ * @since 1.0.0
+ */
+export const productAll: <A>(collection: Iterable<List<A>>) => List<ReadonlyArray<A>> =
+  LI.productAll
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Product: product_.Product<ListTypeLambda> = {
+  ...NonEmptyProduct,
+  ...Of,
+  productAll
+}
+
+/**
+ * @since 1.0.0
+ */
+export const tuple: <T extends ReadonlyArray<List<any>>>(
+  ...components: T
+) => List<Readonly<{ [I in keyof T]: [T[I]] extends [List<infer A>] ? A : never }>> = product_
+  .tuple(Product)
+
+/**
+ * @since 1.0.0
+ */
+export const struct: <R extends Record<string, List<any>>>(
+  fields: R
+) => List<{ readonly [K in keyof R]: [R[K]] extends [List<infer A>] ? A : never }> = product_
+  .struct(Product)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const NonEmptyApplicative: nonEmptyApplicative.NonEmptyApplicative<ListTypeLambda> = {
+  ...NonEmptyProduct,
+  ...Covariant
+}
+
+/**
+ * @since 1.0.0
+ */
+export const liftSemigroup: <A>(S: Semigroup<A>) => Semigroup<List<A>> = nonEmptyApplicative
+  .liftSemigroup(NonEmptyApplicative)
+
+/**
+ * @since 1.0.0
+ */
+export const ap: <A>(
+  fa: List<A>
+) => <B>(self: List<(a: A) => B>) => List<B> = nonEmptyApplicative
+  .ap(NonEmptyApplicative)
+
+/**
+ * @since 1.0.0
+ */
+export const lift2: <A, B, C>(
+  f: (a: A, b: B) => C
+) => (fa: List<A>, fb: List<B>) => List<C> = nonEmptyApplicative.lift2(
+  NonEmptyApplicative
+)
+
+/**
+ * @since 1.0.0
+ */
+export const lift3: <A, B, C, D>(
+  f: (a: A, b: B, c: C) => D
+) => (fa: List<A>, fb: List<B>, fc: List<C>) => List<D> = nonEmptyApplicative.lift3(
+  NonEmptyApplicative
+)
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Applicative: applicative.Applicative<ListTypeLambda> = {
+  ...NonEmptyApplicative,
+  ...Product
+}
+
+/**
+ * @since 1.0.0
+ */
+export const liftMonoid: <A>(M: Monoid<A>) => Monoid<List<A>> = applicative.liftMonoid(
+  Applicative
+)
+
+/**
+ * @since 1.0.0
+ */
+export const reduceRight: <A, B>(b: B, f: (b: B, a: A) => B) => (self: List<A>) => B =
+  LI.reduceRight
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Foldable: foldable.Foldable<ListTypeLambda> = {
+  reduce,
+  reduceRight
+}
+
+/**
+ * @since 1.0.0
+ */
+export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (self: List<A>) => M = foldable
+  .foldMap(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const toReadonlyArray: <A>(self: List<A>) => ReadonlyArray<A> = foldable
+  .toReadonlyArray(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const toReadonlyArrayWith: <A, B>(
+  f: (a: A) => B
+) => (self: List<A>) => ReadonlyArray<B> = foldable.toReadonlyArrayWith(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const reduceKind: <G extends TypeLambda>(
+  G: monad.Monad<G>
+) => <B, A, R, O, E>(
+  b: B,
+  f: (b: B, a: A) => Kind<G, R, O, E, B>
+) => (self: List<A>) => Kind<G, R, O, E, B> = foldable.reduceKind(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const reduceRightKind: <G extends TypeLambda>(
+  G: monad.Monad<G>
+) => <B, A, R, O, E>(
+  b: B,
+  f: (b: B, a: A) => Kind<G, R, O, E, B>
+) => (self: List<A>) => Kind<G, R, O, E, B> = foldable.reduceRightKind(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const foldMapKind: <G extends TypeLambda>(
+  G: Coproduct<G>
+) => <A, R, O, E, B>(
+  f: (a: A) => Kind<G, R, O, E, B>
+) => (self: List<A>) => Kind<G, R, O, E, B> = foldable.foldMapKind(Foldable)
+
+/**
+ * @since 1.0.0
+ */
+export const compact: <A>(self: List<Option<A>>) => List<A> = LI.compact
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Compactable: compactable.Compactable<ListTypeLambda> = {
+  compact
+}
+
+/**
+ * @since 1.0.0
+ */
+export const separate: <A, B>(self: List<Either<A, B>>) => readonly [List<A>, List<B>] = compactable
+  .separate({ ...Compactable, ...Covariant })
+
+/**
+ * @since 1.0.0
+ */
+export const filterMap: <A, B>(f: (a: A) => Option<B>) => (self: List<A>) => List<B> = LI.filterMap
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Filterable: filterable.Filterable<ListTypeLambda> = {
+  filterMap
+}
+
+/**
+ * @since 1.0.0
+ * @category filtering
+ */
+export const filter: {
+  <C extends A, B extends A, A = C>(
+    refinement: (a: A) => a is B
+  ): (self: List<C>) => List<B>
+  <B extends A, A = B>(predicate: (a: A) => boolean): (self: List<B>) => List<B>
+} = filterable.filter(Filterable)
+
+/**
+ * @since 1.0.0
+ * @category filtering
+ */
+export const partition: {
+  <C extends A, B extends A, A = C>(
+    refinement: (a: A) => a is B
+  ): (self: List<C>) => readonly [List<C>, List<B>]
+  <B extends A, A = B>(
+    predicate: (a: A) => boolean
+  ): (self: List<B>) => readonly [List<B>, List<B>]
+} = filterable.partition(Filterable)
+
+/**
+ * @since 1.0.0
+ * @category filtering
+ */
+export const partitionMap: <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => (self: List<A>) => readonly [List<B>, List<C>] = filterable.partitionMap(Filterable)
+
+/**
+ * @since 1.0.0
+ * @category traversing
+ */
+export const traverse: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <A, R, O, E, B>(
+  f: (a: A) => Kind<F, R, O, E, B>
+) => (self: List<A>) => Kind<F, R, O, E, List<B>> = LI.traverse
+
+/**
+ * @since 1.0.0
+ * @category instances
+ */
+export const Traversable: traversable.Traversable<ListTypeLambda> = {
+  traverse
+}
+
+/**
+ * @since 1.0.0
+ * @category traversing
+ */
+export const sequence: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <R, O, E, A>(self: List<Kind<F, R, O, E, A>>) => Kind<F, R, O, E, List<A>> = traversable
+  .sequence(Traversable)
+
+/**
+ * @since 1.0.0
+ * @category traversing
+ */
+export const traverseTap: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <A, R, O, E, B>(
+  f: (a: A) => Kind<F, R, O, E, B>
+) => (self: List<A>) => Kind<F, R, O, E, List<A>> = traversable.traverseTap(Traversable)
+
+/**
+ * @category filtering
+ * @since 1.0.0
+ */
+export const traverseFilterMap: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <A, R, O, E, B>(
+  f: (a: A) => Kind<F, R, O, E, Option<B>>
+) => (self: List<A>) => Kind<F, R, O, E, List<B>> = traversableFilterable.traverseFilterMap(
+  { ...Traversable, ...Compactable }
+)
+
+/**
+ * @category filtering
+ * @since 1.0.0
+ */
+export const traversePartitionMap: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <A, R, O, E, B, C>(
+  f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+) => (self: List<A>) => Kind<F, R, O, E, readonly [List<B>, List<C>]> = traversableFilterable
+  .traversePartitionMap({ ...Traversable, ...Covariant, ...Compactable })
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const TraversableFilterable: traversableFilterable.TraversableFilterable<
+  ListTypeLambda
+> = {
+  traverseFilterMap,
+  traversePartitionMap
+}
+
+/**
+ * @since 1.0.0
+ * @category filtering
+ */
+export const traverseFilter: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <B extends A, R, O, E, A = B>(
+  predicate: (a: A) => Kind<F, R, O, E, boolean>
+) => (self: List<B>) => Kind<F, R, O, E, List<B>> = traversableFilterable.traverseFilter(
+  TraversableFilterable
+)
+
+/**
+ * @since 1.0.0
+ * @category filtering
+ */
+export const traversePartition: <F extends TypeLambda>(
+  F: applicative.Applicative<F>
+) => <B extends A, R, O, E, A = B>(
+  predicate: (a: A) => Kind<F, R, O, E, boolean>
+) => (self: List<B>) => Kind<F, R, O, E, readonly [List<B>, List<B>]> = traversableFilterable
+  .traversePartition(
+    TraversableFilterable
+  )

--- a/test/List.ts
+++ b/test/List.ts
@@ -1,13 +1,214 @@
+import * as E from "@fp-ts/data/Either"
 import { equals } from "@fp-ts/data/Equal"
 import { pipe } from "@fp-ts/data/Function"
 import * as L from "@fp-ts/data/List"
 import * as LB from "@fp-ts/data/mutable/MutableListBuilder"
 import * as Number from "@fp-ts/data/Number"
-import { assertTrue } from "@fp-ts/data/test/util"
+import * as O from "@fp-ts/data/Option"
+import * as U from "@fp-ts/data/test/util"
 
 describe.concurrent("List", () => {
+  it("take", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.take(2))).toEqual(L.make(1, 2))
+    // out of bounds tests
+    expect(pipe(L.make(1, 2, 3, 4), L.take(-2))).toEqual(L.make(1, 2, 3, 4))
+    expect(pipe(L.make(1, 2, 3, 4), L.take(10))).toEqual(L.make(1, 2, 3, 4))
+  })
+
+  it("splitAt", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.splitAt(2))).toEqual([L.make(1, 2), L.make(3, 4)])
+  })
+
+  it("isNil", () => {
+    U.deepStrictEqual(L.isNil(L.nil()), true)
+    U.deepStrictEqual(L.isNil(L.make(1)), false)
+  })
+
+  it("isCons", () => {
+    U.deepStrictEqual(L.isCons(L.make()), false)
+    U.deepStrictEqual(L.isCons(L.make(1)), true)
+  })
+
+  it("prependAll", () => {
+    expect(pipe(L.make(3), L.prependAll(L.make(1, 2)))).toStrictEqual(L.make(1, 2, 3))
+  })
+
+  it("concat", () => {
+    expect(pipe(L.make(1, 2), L.concat(L.make(3, 4)))).toStrictEqual(L.make(1, 2, 3, 4))
+  })
+
+  it("partition", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.partition((n) => n > 2))).toStrictEqual([
+      L.make(1, 2),
+      L.make(3, 4)
+    ])
+  })
+
+  it("partitionMap", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.partitionMap((n) => n > 2 ? E.right(n) : E.left(n))))
+      .toStrictEqual([
+        L.make(1, 2),
+        L.make(3, 4)
+      ])
+  })
+
+  it("head", () => {
+    expect(pipe(L.make(), L.head)).toEqual(O.none)
+    expect(pipe(L.make(1, 2, 3), L.head)).toEqual(O.some(1))
+  })
+
+  it("tail", () => {
+    expect(pipe(L.make(), L.tail)).toEqual(O.none)
+    expect(pipe(L.make(1, 2, 3), L.tail)).toEqual(O.some(L.make(2, 3)))
+  })
+
+  it("some", () => {
+    expect(pipe(L.make(), L.some((n) => n > 2))).toEqual(false)
+    expect(pipe(L.make(1, 2), L.some((n) => n > 2))).toEqual(false)
+    expect(pipe(L.make(2, 3), L.some((n) => n > 2))).toEqual(true)
+    expect(pipe(L.make(3, 4), L.some((n) => n > 2))).toEqual(true)
+  })
+
+  it("every", () => {
+    expect(pipe(L.make(), L.every((n) => n > 2))).toEqual(true)
+    expect(pipe(L.make(1, 2), L.every((n) => n > 2))).toEqual(false)
+    expect(pipe(L.make(2, 3), L.every((n) => n > 2))).toEqual(false)
+    expect(pipe(L.make(3, 4), L.every((n) => n > 2))).toEqual(true)
+  })
+
+  it("findFirst", () => {
+    const item = (a: string, b: string) => ({ a, b })
+    const itemToFind = item("a2", "b2")
+    expect(
+      pipe(
+        L.make(item("a1", "b1"), itemToFind, item("a3", itemToFind.b)),
+        L.findFirst(({ b }) => b === itemToFind.b)
+      )
+    ).toEqual(O.some(itemToFind))
+  })
+
+  it("reduce", () => {
+    expect(pipe(L.make(), L.reduce("-", (b, a) => b + a))).toEqual("-")
+    expect(pipe(L.make("a", "b", "c"), L.reduce("-", (b, a) => b + a))).toEqual("-abc")
+  })
+
   it("constructs a list", () => {
-    assertTrue(equals(Array.from(L.List(0, 1, 2, 3)), [0, 1, 2, 3]))
+    U.assertTrue(equals(Array.from(L.List(0, 1, 2, 3)), [0, 1, 2, 3]))
+  })
+
+  it("drop", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.drop(2))).toEqual(L.make(3, 4))
+  })
+
+  it("map", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.map((n) => n + 1))).toEqual(L.make(2, 3, 4, 5))
+  })
+
+  it("forEach", () => {
+    const as: Array<number> = []
+    pipe(L.make(1, 2, 3, 4), L.forEach((n) => as.push(n)))
+
+    expect(as).toStrictEqual([1, 2, 3, 4])
+  })
+
+  it("flatMap", () => {
+    expect(pipe(L.make(1, 2, 3, 4), L.flatMap((n) => L.make(n - 1, n + 1)))).toEqual(
+      L.make(0, 2, 1, 3, 2, 4, 3, 5)
+    )
+  })
+
+  it("unsafeLast", () => {
+    expect(() => pipe(L.make(), L.unsafeLast)).toThrowError(
+      new Error("Expected List to be not empty")
+    )
+    expect(pipe(L.make(1, 2, 3, 4), L.unsafeLast)).toEqual(4)
+  })
+
+  it("instances and derived exports", () => {
+    expect(L.Invariant).exist
+    expect(L.imap).exist
+    expect(L.tupled).exist
+    expect(L.bindTo).exist
+
+    expect(L.Covariant).exist
+    expect(L.map).exist
+    expect(L.let).exist
+    expect(L.flap).exist
+    expect(L.as).exist
+    expect(L.asUnit).exist
+
+    expect(L.Of).exist
+    expect(L.unit).exist
+    expect(L.of).exist
+    expect(L.Do).exist
+
+    expect(L.Pointed).exist
+
+    expect(L.FlatMap).exist
+    expect(L.flatMap).exist
+    expect(L.flatten).exist
+    expect(L.andThen).exist
+    expect(L.composeKleisliArrow).exist
+
+    expect(L.Chainable).exist
+    expect(L.bind).exist
+    expect(L.tap).exist
+    expect(L.andThenDiscard).exist
+
+    expect(L.Monad).exist
+
+    expect(L.NonEmptyProduct).exist
+    expect(L.product).exist
+    expect(L.productMany).exist
+    expect(L.bindList).exist
+    expect(L.productFlatten).exist
+
+    expect(L.Product).exist
+    expect(L.productAll).exist
+    expect(L.tuple).exist
+    expect(L.struct).exist
+
+    expect(L.NonEmptyApplicative).exist
+    expect(L.liftSemigroup).exist
+    expect(L.lift2).exist
+    expect(L.lift3).exist
+    expect(L.ap).exist
+    expect(L.andThenDiscard).exist
+    expect(L.andThen).exist
+
+    expect(L.Applicative).exist
+    expect(L.liftMonoid).exist
+
+    expect(L.Foldable).exist
+    expect(L.reduce).exist
+    expect(L.reduceRight).exist
+    expect(L.foldMap).exist
+    expect(L.toReadonlyArray).exist
+    expect(L.toReadonlyArrayWith).exist
+    expect(L.reduceKind).exist
+    expect(L.reduceRightKind).exist
+    expect(L.foldMapKind).exist
+
+    expect(L.Traversable).exist
+    expect(L.traverse).exist
+    expect(L.sequence).exist
+    expect(L.traverseTap).exist
+
+    expect(L.Compactable).exist
+    expect(L.compact).exist
+    expect(L.separate).exist
+
+    expect(L.Filterable).exist
+    expect(L.filterMap).exist
+    expect(L.filter).exist
+    expect(L.partition).exist
+    expect(L.partitionMap).exist
+
+    expect(L.TraversableFilterable).exist
+    expect(L.traverseFilterMap).exist
+    expect(L.traversePartitionMap).exist
+    expect(L.traverseFilter).exist
+    expect(L.traversePartition).exist
   })
 
   it("constructs a list via builder", () => {
@@ -15,7 +216,7 @@ describe.concurrent("List", () => {
     for (let i = 0; i <= 3; i++) {
       pipe(builder, LB.append(i))
     }
-    assertTrue(pipe(builder, LB.toList, equals(L.List(0, 1, 2, 3))))
+    U.assertTrue(pipe(builder, LB.toList, equals(L.List(0, 1, 2, 3))))
   })
 
   it("sort", () => {


### PR DESCRIPTION
This is more a showcase of what can be derived from the instances. 

We can either merge it as is and later remove the superfluous functions or, if you mark the not interesting ones, I can remove them in a forthcoming commit.

There's also a fix for the `take` function.

**src/internal/List**

The new functions defined in `src/internal/List` are not optimised

- `product`
- `productMany`
- `productAll`
- `reduceRight`
- `filterMap`
- `compact`

The following pre-existing functions

- `filter`
- `partition`
- `partitionMap`

are no more used by `src/List` (they are now derived), can I remove them?

**test/List**

added 100% coverage
