### PR TITLE
Fix Chunk.zipWith

### DIFF
--- a/.changeset/calm-turkeys-sit.md
+++ b/.changeset/calm-turkeys-sit.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/data": patch
+---
+
+fix Chunk.zipWith

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1381,7 +1381,7 @@ export const zipWith = <A, B, C>(that: Chunk<B>, f: (a: A, b: B) => C) =>
     const len = Math.min(selfA.length, thatA.length)
     const res: Array<C> = new Array(len)
     for (let i = 0; i < len; i++) {
-      res.push(f(selfA[i], thatA[i]))
+      res[i] = f(selfA[i], thatA[i])
     }
     return unsafeFromArray(res)
   }

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -448,6 +448,33 @@ describe.concurrent("Chunk", () => {
     // TODO add tests for 100% coverage: left & right diff depths & depth > 0
   })
 
+  it("zip", () => {
+    pipe(
+      C.empty,
+      C.zip(C.empty),
+      equals(C.unsafeFromArray([])),
+      assert.isTrue
+    )
+    pipe(
+      C.empty,
+      C.zip(C.singleton(1)),
+      equals(C.unsafeFromArray([])),
+      assert.isTrue
+    )
+    pipe(
+      C.singleton(1),
+      C.zip(C.empty),
+      equals(C.unsafeFromArray([])),
+      assert.isTrue
+    )
+    pipe(
+      C.singleton(1),
+      C.zip(C.singleton(2)),
+      equals(C.unsafeFromArray([[1, 2]])),
+      assert.isTrue
+    )
+  })
+
   it("zipWithIndex", () => {
     pipe(
       C.empty,


### PR DESCRIPTION
Previously, the following lines would create a new array with `len` elements, all of which are `undefined`.

```ts
const len = Math.min(selfA.length, thatA.length)
const res: Array<C> = new Array(len)
for (let i = 0; i < len; i++) {
  res.push(f(selfA[i], thatA[i]))
}
```

Using `Array.push` appends elements to the new array, instead of overwriting the `undefined` elements.

This PR fixes that issue.