### PR TITLE
Reintroduce NonEmptyArray, not as tuple

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1118,7 +1118,7 @@ export const last = <A>(self: Chunk<A>): Option<A> => get(self.length - 1)(self)
  * @since 1.0.0
  * @category constructors
  */
-export const make = <As extends readonly [any, ...ReadonlyArray<any>]>(
+export const make = <As extends RA.NonEmptyArray<any>>(
   ...as: As
 ): NonEmptyChunk<As[number]> => unsafeFromArray(as) as any
 
@@ -1140,7 +1140,7 @@ export const singleton = <A>(a: A): NonEmptyChunk<A> =>
  * @category constructors
  */
 export const makeBy = <A>(f: (i: number) => A) =>
-  (n: number): NonEmptyChunk<A> => make(...RA.makeBy(f)(n))
+  (n: number): NonEmptyChunk<A> => make(...RA.makeBy(f)(n) as [A, ...Array<A>])
 
 /**
  * Returns an effect whose success is mapped by the specified f function.

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -50,13 +50,13 @@ export interface ReadonlyArrayTypeLambda extends TypeLambda {
  * @category models
  * @since 1.0.0
  */
-export type NonEmptyReadonlyArray<A> = readonly [A, ...Array<A>]
+export type NonEmptyReadonlyArray<A> = ReadonlyArray<A> & { 0: A }
 
 /**
  * @category models
  * @since 1.0.0
  */
-export type NonEmptyArray<A> = [A, ...Array<A>]
+export type NonEmptyArray<A> = Array<A> & { 0: A }
 
 /**
  * Builds a `NonEmptyArray` from an non-empty collection of elements.

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -50,13 +50,17 @@ export interface ReadonlyArrayTypeLambda extends TypeLambda {
  * @category models
  * @since 1.0.0
  */
-export type NonEmptyReadonlyArray<A> = ReadonlyArray<A> & { 0: A }
+export interface NonEmptyReadonlyArray<A> extends ReadonlyArray<A> {
+  0: A
+}
 
 /**
  * @category models
  * @since 1.0.0
  */
-export type NonEmptyArray<A> = Array<A> & { 0: A }
+export interface NonEmptyArray<A> extends Array<A> {
+  0: A
+}
 
 /**
  * Builds a `NonEmptyArray` from an non-empty collection of elements.


### PR DESCRIPTION
@gcanti how to deal with productMany & friends leveraging `[A, ...A[]]`