### PR TITLE
feat: add Context.make constructor

### DIFF
--- a/.changeset/perfect-crews-yawn.md
+++ b/.changeset/perfect-crews-yawn.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/data": patch
+---
+
+Add Context.make

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -87,6 +87,12 @@ export const empty: () => Context<never> = C.empty
 
 /**
  * @since 1.0.0
+ * @category constructors
+ */
+export const make: <S>(tag: Tag<S>) => (service: S) => Context<S> = C.make
+
+/**
+ * @since 1.0.0
  * @category mutations
  */
 export const add: <S>(

--- a/src/internal/Context.ts
+++ b/src/internal/Context.ts
@@ -78,6 +78,10 @@ export function empty(): C.Context<never> {
   return new ContextImpl<never>(new Map())
 }
 
+export function make<S>(tag: C.Tag<S>) {
+  return (service: S): C.Context<S> => new ContextImpl<S>(new Map([[tag, service]]))
+}
+
 export function add<S>(tag: C.Tag<S>) {
   return (service: S) => {
     return <Services>(self: C.Context<Services>): C.Context<Services | S> => {

--- a/test/Context.ts
+++ b/test/Context.ts
@@ -25,10 +25,10 @@ describe.concurrent("Context", () => {
     const b = Context.Tag<number>("@fp-ts/data/test/Context/Tag")
     expect(a).toBe(b)
   })
+
   it("adds and retrieve services", () => {
     const Services = pipe(
-      Context.empty(),
-      Context.add(A)({ a: 0 }),
+      Context.make(A)({ a: 0 }),
       Context.add(B)({ b: 1 })
     )
 

--- a/test/Json.ts
+++ b/test/Json.ts
@@ -10,7 +10,7 @@ describe("Json", () => {
     U.deepStrictEqual(pipe("{\"a\":1}", _.parse), E.right({ a: 1 }))
     U.deepStrictEqual(
       pipe("{\"a\":}", _.parse),
-      E.left(new SyntaxError("Unexpected token } in JSON at position 5"))
+      E.left(new SyntaxError(`Unexpected token '}', "{"a":}" is not valid JSON`))
     )
   })
 

--- a/test/Json.ts
+++ b/test/Json.ts
@@ -9,8 +9,8 @@ describe("Json", () => {
   it("parse", () => {
     U.deepStrictEqual(pipe("{\"a\":1}", _.parse), E.right({ a: 1 }))
     U.deepStrictEqual(
-      pipe("{\"a\":}", _.parse),
-      E.left(new SyntaxError(`Unexpected token '}', "{"a":}" is not valid JSON`))
+      pipe("{\"a\":}", _.parse, E.mapLeft(() => "invalid json")),
+      E.left("invalid json")
     )
   })
 


### PR DESCRIPTION
As I'm using the Context module, I keep creating a helper for constructing a context from a single tag and service to avoid reaching for pipe, empty, and add. I figured it was a simple enough change to go ahead and make a PR for it. 

As I was running the test suite, I noticed a failure in JSON.parse, so I also went ahead and fixed that. I'm running the tests with node v19.3.0, so potentially that's relevant to the error message being different.