### PR TITLE
Revert "use interface over type where possible"

### DIFF
--- a/.changeset/friendly-kids-develop.md
+++ b/.changeset/friendly-kids-develop.md
@@ -1,5 +1,0 @@
----
-"@fp-ts/data": patch
----
-
-Use interface over type where possible

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -110,8 +110,8 @@ Added in v1.0.0
   - [tupled](#tupled)
 - [models](#models)
   - [Either (type alias)](#either-type-alias)
-  - [Left (interface)](#left-interface)
-  - [Right (interface)](#right-interface)
+  - [Left (type alias)](#left-type-alias)
+  - [Right (type alias)](#right-type-alias)
 - [mutations](#mutations)
   - [reverse](#reverse)
 - [pattern matching](#pattern-matching)
@@ -1145,12 +1145,12 @@ export type Either<E, A> = Left<E> | Right<A>
 
 Added in v1.0.0
 
-## Left (interface)
+## Left (type alias)
 
 **Signature**
 
 ```ts
-export interface Left<E> extends J.StringIndexed {
+export type Left<E> = {
   readonly _tag: 'Left'
   readonly left: E
 }
@@ -1158,12 +1158,12 @@ export interface Left<E> extends J.StringIndexed {
 
 Added in v1.0.0
 
-## Right (interface)
+## Right (type alias)
 
 **Signature**
 
 ```ts
-export interface Right<A> extends J.StringIndexed {
+export type Right<A> = {
   readonly _tag: 'Right'
   readonly right: A
 }

--- a/docs/modules/Json.ts.md
+++ b/docs/modules/Json.ts.md
@@ -16,7 +16,6 @@ Added in v1.0.0
   - [Json (type alias)](#json-type-alias)
   - [JsonArray (type alias)](#jsonarray-type-alias)
   - [JsonObject (type alias)](#jsonobject-type-alias)
-  - [StringIndexed (interface)](#stringindexed-interface)
   - [parse](#parse)
   - [stringify](#stringify)
 
@@ -49,19 +48,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export type JsonObject = StringIndexed<Json>
-```
-
-Added in v1.0.0
-
-## StringIndexed (interface)
-
-**Signature**
-
-```ts
-export interface StringIndexed<A = any> {
-  readonly [k: string]: A
-}
+export type JsonObject = { readonly [key: string]: Json }
 ```
 
 Added in v1.0.0

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -104,9 +104,9 @@ Added in v1.0.0
   - [imap](#imap)
   - [map](#map)
 - [models](#models)
-  - [None (interface)](#none-interface)
+  - [None (type alias)](#none-type-alias)
   - [Option (type alias)](#option-type-alias)
-  - [Some (interface)](#some-interface)
+  - [Some (type alias)](#some-type-alias)
 - [pattern matching](#pattern-matching)
   - [match](#match)
 - [sequencing](#sequencing)
@@ -1113,12 +1113,12 @@ Added in v1.0.0
 
 # models
 
-## None (interface)
+## None (type alias)
 
 **Signature**
 
 ```ts
-export interface None extends J.StringIndexed {
+export type None = {
   readonly _tag: 'None'
 }
 ```
@@ -1135,12 +1135,12 @@ export type Option<A> = None | Some<A>
 
 Added in v1.0.0
 
-## Some (interface)
+## Some (type alias)
 
 **Signature**
 
 ```ts
-export interface Some<A> extends J.StringIndexed {
+export type Some<A> = {
   readonly _tag: 'Some'
   readonly value: A
 }

--- a/docs/modules/These.ts.md
+++ b/docs/modules/These.ts.md
@@ -139,7 +139,7 @@ Added in v1.0.0
   - [map](#map)
   - [tupled](#tupled)
 - [model](#model)
-  - [Both (interface)](#both-interface)
+  - [Both (type alias)](#both-type-alias)
   - [These (type alias)](#these-type-alias)
   - [Validated (type alias)](#validated-type-alias)
 - [pattern matching](#pattern-matching)
@@ -1269,12 +1269,12 @@ Added in v1.0.0
 
 # model
 
-## Both (interface)
+## Both (type alias)
 
 **Signature**
 
 ```ts
-export interface Both<E, A> extends J.StringIndexed {
+export type Both<E, A> = {
   readonly _tag: 'Both'
   readonly left: E
   readonly right: A

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -37,7 +37,6 @@ import type { LazyArg } from "@fp-ts/data/Function"
 import { constNull, constUndefined, identity, pipe } from "@fp-ts/data/Function"
 import * as either from "@fp-ts/data/internal/Either"
 import * as option from "@fp-ts/data/internal/Option"
-import type * as J from "@fp-ts/data/Json"
 import type { Option } from "@fp-ts/data/Option"
 import type { Predicate, Refinement } from "@fp-ts/data/Predicate"
 import * as Gen from "@fp-ts/data/typeclass/Gen"
@@ -46,7 +45,7 @@ import * as Gen from "@fp-ts/data/typeclass/Gen"
  * @category models
  * @since 1.0.0
  */
-export interface Left<E> extends J.StringIndexed {
+export type Left<E> = {
   readonly _tag: "Left"
   readonly left: E
 }
@@ -55,7 +54,7 @@ export interface Left<E> extends J.StringIndexed {
  * @category models
  * @since 1.0.0
  */
-export interface Right<A> extends J.StringIndexed {
+export type Right<A> = {
   readonly _tag: "Right"
   readonly right: A
 }

--- a/src/Json.ts
+++ b/src/Json.ts
@@ -13,14 +13,7 @@ export type JsonArray = ReadonlyArray<Json>
 /**
  * @since 1.0.0
  */
-export type JsonObject = StringIndexed<Json>
-
-/**
- * @since 1.0.0
- */
-export interface StringIndexed<A = any> {
-  readonly [k: string]: A
-}
+export type JsonObject = { readonly [key: string]: Json }
 
 /**
  * @since 1.0.0

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -41,7 +41,6 @@ import { constNull, constUndefined, pipe } from "@fp-ts/data/Function"
 import * as internal from "@fp-ts/data/internal/Common"
 import * as either from "@fp-ts/data/internal/Either"
 import * as option from "@fp-ts/data/internal/Option"
-import type * as J from "@fp-ts/data/Json"
 import type { Predicate, Refinement } from "@fp-ts/data/Predicate"
 import * as compactable from "@fp-ts/data/typeclass/Compactable"
 import * as filterable from "@fp-ts/data/typeclass/Filterable"
@@ -51,7 +50,7 @@ import * as Gen from "@fp-ts/data/typeclass/Gen"
  * @category models
  * @since 1.0.0
  */
-export interface None extends J.StringIndexed {
+export type None = {
   readonly _tag: "None"
 }
 
@@ -59,7 +58,7 @@ export interface None extends J.StringIndexed {
  * @category models
  * @since 1.0.0
  */
-export interface Some<A> extends J.StringIndexed {
+export type Some<A> = {
   readonly _tag: "Some"
   readonly value: A
 }

--- a/src/These.ts
+++ b/src/These.ts
@@ -45,7 +45,6 @@ import { constNull, constUndefined, pipe } from "@fp-ts/data/Function"
 import * as either from "@fp-ts/data/internal/Either"
 import * as option from "@fp-ts/data/internal/Option"
 import * as these from "@fp-ts/data/internal/These"
-import type * as J from "@fp-ts/data/Json"
 import type { Option } from "@fp-ts/data/Option"
 import type { Predicate, Refinement } from "@fp-ts/data/Predicate"
 import type { NonEmptyReadonlyArray } from "@fp-ts/data/ReadonlyArray"
@@ -56,7 +55,7 @@ import * as Gen from "@fp-ts/data/typeclass/Gen"
  * @category model
  * @since 1.0.0
  */
-export interface Both<E, A> extends J.StringIndexed {
+export type Both<E, A> = {
   readonly _tag: "Both"
   readonly left: E
   readonly right: A


### PR DESCRIPTION
This reverts commit 4cb63ca5bef8e3af9a0c4b9c86fd5fb45568e6a6.
