### PR TITLE
Handle concat cases in Chunk.drop/Chunk.take

### DIFF
--- a/.changeset/sour-carrots-study.md
+++ b/.changeset/sour-carrots-study.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/data": patch
+---
+
+handle concat cases in Chunk.drop/Chunk.take

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -693,6 +693,16 @@ export const take = (n: number) =>
             offset: self.backing.offset
           })
         }
+        case "IConcat": {
+          if (n > self.left.length) {
+            return new ChunkImpl({
+              _tag: "IConcat",
+              left: self.left,
+              right: take(n - self.left.length)(self.right)
+            })
+          }
+          return take(n)(self.left)
+        }
         default: {
           return new ChunkImpl({
             _tag: "ISlice",
@@ -726,6 +736,16 @@ export const drop = (n: number) =>
             chunk: self.backing.chunk,
             length: self.backing.length - n,
             offset: self.backing.offset + n
+          })
+        }
+        case "IConcat": {
+          if (n > self.left.length) {
+            return drop(n - self.left.length)(self.right)
+          }
+          return new ChunkImpl({
+            _tag: "IConcat",
+            left: drop(n)(self.left),
+            right: self.right
           })
         }
         default: {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1514,12 +1514,7 @@ export const zipWith = <A, B, C>(that: Chunk<B>, f: (a: A, b: B) => C) =>
   (self: Chunk<A>): Chunk<C> => {
     const selfA = toReadonlyArray(self)
     const thatA = toReadonlyArray(that)
-    const len = Math.min(selfA.length, thatA.length)
-    const res: Array<C> = new Array(len)
-    for (let i = 0; i < len; i++) {
-      res[i] = f(selfA[i], thatA[i])
-    }
-    return unsafeFromArray(res)
+    return pipe(selfA, RA.zipWith(thatA, f), unsafeFromArray)
   }
 
 /**

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -688,7 +688,7 @@ export const take = (n: number) =>
         case "ISlice": {
           return new ChunkImpl({
             _tag: "ISlice",
-            chunk: self,
+            chunk: self.backing.chunk,
             length: n,
             offset: self.backing.offset
           })

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -1,5 +1,4 @@
 import * as C from "@fp-ts/data/Chunk"
-import * as E from "@fp-ts/data/Either"
 import { equals } from "@fp-ts/data/Equal"
 import { pipe } from "@fp-ts/data/Function"
 import * as O from "@fp-ts/data/Option"
@@ -565,30 +564,12 @@ describe.concurrent("Chunk", () => {
   })
 
   describe("Given two non-materialized chunks of different sizes", () => {
-    it("should zip the chunks together and return the leftover", () => {
-      const zipChunks = <A, B, C>(
-        left: C.Chunk<A>,
-        right: C.Chunk<B>,
-        f: (a: A, b: B) => C
-      ): readonly [C.Chunk<C>, E.Either<C.Chunk<A>, C.Chunk<B>>] => {
-        if (left.length > right.length) {
-          return [
-            pipe(left, C.take(right.length), C.zipWith(right, f)),
-            E.left(pipe(left, C.drop(right.length)))
-          ] as const
-        }
-        return [
-          pipe(left, C.zipWith(pipe(right, C.take(left.length)), f)),
-          E.right(pipe(right, C.drop(left.length)))
-        ] as const
-      }
+    it.only("should zip the chunks together and return the leftover", () => {
       // Create two non-materialized Chunks
       const left = pipe(C.make(-1, 0, 1), C.drop(1))
       const right = pipe(C.make(1, 0, 0, 1), C.drop(1))
-      const [zipped, either] = zipChunks(left, right, (a, b) => [a, b])
-      const leftover = pipe(either, E.bimap(C.toReadonlyArray, C.toReadonlyArray))
+      const zipped = pipe(left, C.zipWith(pipe(right, C.take(left.length)), (a, b) => [a, b]))
       expect(Array.from(zipped)).toEqual([[0, 0], [1, 0]])
-      expect(leftover).toEqual(E.right([1]))
     })
   })
 })

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -333,6 +333,15 @@ describe.concurrent("Chunk", () => {
         ]))
       })
     })
+
+    describe("Given a concatenated Chunk and an amount > 1", () => {
+      const chunk = pipe(C.singleton(1), C.concat(C.make(2, 3, 4)))
+      const amount = 2
+
+      it("should return the available subset", () => {
+        expect(pipe(chunk, C.take(amount), C.toReadonlyArray)).toEqual([1, 2])
+      })
+    })
   })
 
   describe("make", () => {
@@ -358,6 +367,10 @@ describe.concurrent("Chunk", () => {
     it("should drop twice", () => {
       const self = C.make(0, 1, 2, 3)
       expect(C.toReadonlyArray(C.drop(1)(C.drop(1)(self)))).toEqual([2, 3])
+    })
+    it("should handle concatenated chunks", () => {
+      const self = pipe(C.make(1), C.concat(C.make(2, 3, 4)))
+      expect(pipe(self, C.drop(2), C.toReadonlyArray)).toEqual([3, 4])
     })
   })
 

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -564,7 +564,7 @@ describe.concurrent("Chunk", () => {
   })
 
   describe("Given two non-materialized chunks of different sizes", () => {
-    it.only("should zip the chunks together and return the leftover", () => {
+    it("should zip the chunks together and return the leftover", () => {
       // Create two non-materialized Chunks
       const left = pipe(C.make(-1, 0, 1), C.drop(1))
       const right = pipe(C.make(1, 0, 0, 1), C.drop(1))


### PR DESCRIPTION
See:
- `Chunk.drop`: https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/Chunk.scala#L271
- `Chunk.take`: https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/Chunk.scala#L816